### PR TITLE
Bind redis on 0.0.0.0 instead of 127.0.0.1

### DIFF
--- a/3.0-alpine/redis.conf
+++ b/3.0-alpine/redis.conf
@@ -1,3 +1,4 @@
+bind 0.0.0.0
 cluster-enabled yes
 cluster-node-timeout 5000
 cluster-config-file nodes.conf

--- a/3.0-alpine/start.sh
+++ b/3.0-alpine/start.sh
@@ -7,6 +7,11 @@ lock_file=/data/cluster.lock
 
 mkdir -p $log_dir
 
+redis_host="0.0.0.0"
+if [ -n "$REDIS_HOSTNAME" ]; then
+  echo "0.0.0.0   $REDIS_HOSTNAME" >> /etc/hosts
+fi
+
 # Initialize configs
 for p in 7000 7001 7002 7003 7004 7005
 do
@@ -33,7 +38,7 @@ sleep 3
 # Create Redis cluster
 if [ ! -f $lock_file ]; then
   touch $lock_file
-  echo "yes" | /redis-trib.rb create --replicas 1 127.0.0.1:7000 127.0.0.1:7001 127.0.0.1:7002 127.0.0.1:7003 127.0.0.1:7004 127.0.0.1:7005
+  echo "yes" | /redis-trib.rb create --replicas 1 "$redis_host":7000 "$redis_host":7001 "$redis_host":7002 "$redis_host":7003 "$redis_host":7004 "$redis_host":7005
 fi
 
 tail -f $log_dir/*.log

--- a/3.0/redis.conf
+++ b/3.0/redis.conf
@@ -1,3 +1,4 @@
+bind 0.0.0.0
 cluster-enabled yes
 cluster-node-timeout 5000
 cluster-config-file nodes.conf

--- a/3.0/start.sh
+++ b/3.0/start.sh
@@ -7,6 +7,11 @@ lock_file=/data/cluster.lock
 
 mkdir -p $log_dir
 
+redis_host="0.0.0.0"
+if [ -n "$REDIS_HOSTNAME" ]; then
+  echo "0.0.0.0   $REDIS_HOSTNAME" >> /etc/hosts
+fi
+
 # Initialize configs
 for p in 7000 7001 7002 7003 7004 7005
 do
@@ -33,7 +38,7 @@ sleep 3
 # Create Redis cluster
 if [ ! -f $lock_file ]; then
   touch $lock_file
-  echo "yes" | /redis-trib.rb create --replicas 1 127.0.0.1:7000 127.0.0.1:7001 127.0.0.1:7002 127.0.0.1:7003 127.0.0.1:7004 127.0.0.1:7005
+  echo "yes" | /redis-trib.rb create --replicas 1 "$redis_host":7000 "$redis_host":7001 "$redis_host":7002 "$redis_host":7003 "$redis_host":7004 "$redis_host":7005
 fi
 
 tail -f $log_dir/*.log

--- a/3.2-alpine/redis.conf
+++ b/3.2-alpine/redis.conf
@@ -1,3 +1,4 @@
+bind 0.0.0.0
 cluster-enabled yes
 cluster-node-timeout 5000
 cluster-config-file nodes.conf

--- a/3.2-alpine/start.sh
+++ b/3.2-alpine/start.sh
@@ -7,6 +7,11 @@ lock_file=/data/cluster.lock
 
 mkdir -p $log_dir
 
+redis_host="0.0.0.0"
+if [ -n "$REDIS_HOSTNAME" ]; then
+  echo "0.0.0.0   $REDIS_HOSTNAME" >> /etc/hosts
+fi
+
 # Initialize configs
 for p in 7000 7001 7002 7003 7004 7005
 do
@@ -33,7 +38,7 @@ sleep 3
 # Create Redis cluster
 if [ ! -f $lock_file ]; then
   touch $lock_file
-  echo "yes" | /redis-trib.rb create --replicas 1 127.0.0.1:7000 127.0.0.1:7001 127.0.0.1:7002 127.0.0.1:7003 127.0.0.1:7004 127.0.0.1:7005
+  echo "yes" | /redis-trib.rb create --replicas 1 "$redis_host":7000 "$redis_host":7001 "$redis_host":7002 "$redis_host":7003 "$redis_host":7004 "$redis_host":7005
 fi
 
 tail -f $log_dir/*.log

--- a/3.2/redis.conf
+++ b/3.2/redis.conf
@@ -1,3 +1,4 @@
+bind 0.0.0.0
 cluster-enabled yes
 cluster-node-timeout 5000
 cluster-config-file nodes.conf

--- a/3.2/start.sh
+++ b/3.2/start.sh
@@ -7,6 +7,11 @@ lock_file=/data/cluster.lock
 
 mkdir -p $log_dir
 
+redis_host="0.0.0.0"
+if [ -n "$REDIS_HOSTNAME" ]; then
+  echo "0.0.0.0   $REDIS_HOSTNAME" >> /etc/hosts
+fi
+
 # Initialize configs
 for p in 7000 7001 7002 7003 7004 7005
 do
@@ -33,7 +38,7 @@ sleep 3
 # Create Redis cluster
 if [ ! -f $lock_file ]; then
   touch $lock_file
-  echo "yes" | /redis-trib.rb create --replicas 1 127.0.0.1:7000 127.0.0.1:7001 127.0.0.1:7002 127.0.0.1:7003 127.0.0.1:7004 127.0.0.1:7005
+  echo "yes" | /redis-trib.rb create --replicas 1 "$redis_host":7000 "$redis_host":7001 "$redis_host":7002 "$redis_host":7003 "$redis_host":7004 "$redis_host":7005
 fi
 
 tail -f $log_dir/*.log


### PR DESCRIPTION
Bind redis on 0.0.0.0 instead of 127.0.0.1.

This make redis can be connected by the outside world or other containers without local port forwarding.

Allow to set $REDIS_HOSTNAME to map to 0.0.0.0